### PR TITLE
Implementing Below Comments..

### DIFF
--- a/app/scripts/controllers/lessons/Update.js
+++ b/app/scripts/controllers/lessons/Update.js
@@ -43,7 +43,10 @@ angular.module('lergoApp').controller('LessonsUpdateCtrl',
                 if (!$scope.lesson.language) {
                     $scope.lesson.language = LergoTranslate.getLanguageObject().name;
                 }
-			}, function(result) {
+                // Advance option should be option is any of the below properties are defined/non-empty
+                $scope.advanceOptionCollapsed = !$scope.lesson.nextLesson && !$scope.lesson.priorLesson && !$scope.lesson.coverPage
+
+            }, function(result) {
 				$scope.errorMessage = 'Error in fetching Lesson by id : ' + result.data.message;
 				$log.error($scope.errorMessage);
 			});

--- a/app/views/invites/_index.html
+++ b/app/views/invites/_index.html
@@ -57,7 +57,8 @@
 							<span class="{{!invite.finished && 'bold' || ''}}">{{invite.invitee.name || invite.invitee.class}}</span>
 						</td>
                         <td class="answer">
-                            <span >{{!!invite.emailNotification}}</span>
+                            <span class="text-success" ng-show="invite.emailNotification">{{'on' | translate }} </span>
+                            <span class= "text-warning" ng-show="!invite.emailNotification">{{'off' | translate}}</span>
                         </td>
 						<td class="answer">
 							<span class="{{!invite.finished && 'bold' || ''}}">{{invite.language && ('filters.languages.' + invite.language | translate) ||""}}</span>

--- a/app/views/lessons/update.html
+++ b/app/views/lessons/update.html
@@ -52,15 +52,14 @@
                 <div class="advance-options">
                     <div class="lergo-h1">
                         <br>
-                        <button class="btn-link expander" ng-click="isCollapsed = !isCollapsed" ng-show="!!lesson.name">
-                            <i ng-show="!isCollapsed" class="fa fa-plus-square"></i>
-                            <i ng-show="!!isCollapsed" class="fa fa-minus-square"></i>
+                        <button class="btn-link expander" ng-click="advanceOptionCollapsed = !advanceOptionCollapsed"
+                                ng-show="!!lesson.name">
+                            <i ng-show="!!advanceOptionCollapsed" class="fa fa-plus-square"></i>
+                            <i ng-show="!advanceOptionCollapsed" class="fa fa-minus-square"></i>
                             {{ 'advancedOptions' | translate }}
                         </button>
-                        {{(isCollapsed===undefined)&& (isCollapsed = (!!lesson.nextLesson || !!lesson.priorLesson ))||""
-                        }}
                     </div>
-                    <div collapse="!isCollapsed">
+                    <div collapse="advanceOptionCollapsed">
                         <hr>
                         <table class=" lergo-table lergo-form">
                             <tbody>
@@ -81,7 +80,8 @@
                             <tr>
                                 <td>{{ 'lessons.addCoverPage' | translate }}</td>
                                 <td>
-                                    <input placeholder="{{'lessons.addCoverPageHint' | translate}}"
+                                    <input lergo-input-converter
+                                           placeholder="{{'lessons.addCoverPageHint' | translate}}"
                                            ng-model="lesson.coverPage"/>
                                 </td>
                             </tr>
@@ -135,8 +135,11 @@
 
                 </div>
                 <div class="lesson-actions"> <!-- lesson actions -->
-                    <button class="btn" ng-click="done()" ng-disabled="saveButtonDisabled()">{{'done' | translate }}</button>
-                    <button class="btn" ng-click="done('showLesson')" ng-disabled="saveButtonDisabled()">{{'button.showLesson' | translate }}</button>
+                    <button class="btn" ng-click="done()" ng-disabled="saveButtonDisabled()">{{'done' | translate }}
+                    </button>
+                    <button class="btn" ng-click="done('showLesson')" ng-disabled="saveButtonDisabled()">
+                        {{'button.showLesson' | translate }}
+                    </button>
                     <span class="pop-up-hint add-step-button">
 						<button class="btn btn-start" ng-click="addStep(lesson)"
                                 ng-disabled="saveButtonDisabled()">{{ 'steps.add' | translate }}</button>
@@ -146,7 +149,8 @@
 							<!--  tabindex = 0 is use to fix focus trigger problem in google chrome -->
 							<button popover="{{'steps.addHint' | translate}}"
                                     popover-is-open="popoverState.open"
-                                    popover-placement="{{popoverState.position}}" popover-trigger="focus" tabindex="0"></button>
+                                    popover-placement="{{popoverState.position}}" popover-trigger="focus"
+                                    tabindex="0"></button>
 						</span>
                     </span>
 


### PR DESCRIPTION
#3.1 You should look at “add image” for question, and you can see that Guy recently implemented a conversion of Google Drive URLs to “correct” URLs - there are 2 types of Google drive links for image that are not valid “as is” and Guy converted them, so that as soon as you paste them they are “automatically” converted to the correct link. Please implement same mechanism for this (or refer to that function, to avoid duplication of code, etc.).
#3.2 Another small comment, that if image is filled (or any of the 3 fields of “advanced options”), then the + is open, so that when I create “edit lesson” again, I see the link, and I don’t have to click on +.
#1.2 ⇒ Did a few more tests, and also updated Hebrew translations in Phraseapp. One more comment is: that False/True will be a key in Phraseapp that is translatable - I will put “on” and “off” for English, and for hebrew it would be something similar in Hebrew.  Also, is it possible that on would be in color “green” and “off” will be in color orange?
