### PR TITLE
Report recommended lesson visibility issue

### DIFF
--- a/app/views/lessons/invitations/report.html
+++ b/app/views/lessons/invitations/report.html
@@ -177,7 +177,7 @@
             </div>
             <hr/>
             <div class="recommendation row" collapse="!!recommendationCollapsed">
-                <div class="row row-nested top20">
+                <div class="row row-nested top20" ng-show="!!report.data.lesson.nextLessonId">
                     <div class="col-md-3">
                         <div class="row">
                             <div class="col-md-2">
@@ -194,7 +194,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="row row-nested top20">
+                <div class="row row-nested top20" ng-show="!!report.data.lesson.priorLessonId">
                     <div class="col-md-3">
                         <div class="row">
                             <div class="col-md-2">


### PR DESCRIPTION
Issue : If user defines “recommended next lesson”, but not “recommend…ed previous lesson”, or vice versa (defined “recommended previous lesson” but not “recommended next lesson”, then in lesson report, the item for the recommendation that the lesson link is not , an undefined appears there

Fix : check whether next lesson or previous lesson exists then only show the div
