### PR TITLE
3.1A My comment here is that when there is a lesson that has been “li…

### DIFF
--- a/app/styles/_lessonIntro.scss
+++ b/app/styles/_lessonIntro.scss
@@ -109,7 +109,7 @@
                 }
                 & > .btn-link, & > div {
                     display: inline-block;
-                    margin-left: 14px;
+                    margin-left: 8px;
                     font-size: 20px;
                 }
             }

--- a/app/views/questions/update.html
+++ b/app/views/questions/update.html
@@ -4,6 +4,6 @@
 	<div class="lergo-h3" ng-show="isValid(quizItem)">{{ isSaving() && ('saving'| translate) || ('saved' | translate) }}</div>
 	<div>
 		<button class="btn" ng-click="done()" ng-disabled="isSaving()||!isValid(quizItem)">{{ 'done' | translate }}</button>
-		<a class="btn update-question-preview" ng-disabled="isSaving()||!isValid(quizItem)" href="#!/user/questions/{{quizItem._id}}/read"> {{ 'preview' | translate }} </a>
+		<a class="btn update-question-preview" ng-disabled="isSaving()||!isValid(quizItem)" href="#!/user/questions/{{quizItem._id}}/read"> {{ 'previewQuestion' | translate }} </a>
 	</div>
 </div>


### PR DESCRIPTION
…ked” by user, then the preview button and the < mark for reporting abuse on lessons is beneath it (see image in folder), we don’t want users to accidentally click on it, so need to make sure that it doesn’t happen.

3.1B (JIRA 648) Add new key for Preview in Edit Question: Preview key in Edit Question should be different vs. preview key in Lesson Intro..  we need to define a new key for "Preview" for Edit Question.  See attached image.
